### PR TITLE
Safer migration of gpxpod_tracks if a nightly > 5.0.0 was installed before

### DIFF
--- a/lib/Migration/Version050000Date20221116114851.php
+++ b/lib/Migration/Version050000Date20221116114851.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Your name <your@email.com>
+ *
+ * @author Your name <your@email.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GpxPod\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version050000Date20221116114851 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+                /** @var ISchemaWrapper $schema */
+                $schema = $schemaClosure();
+                $table = $schema->getTable('gpxpod_tracks');
+                if ($table->hasColumn('enabled') && $table->hasColumn('is_enabled') ) {
+                        $table->dropColumn('enabled');
+                }
+                return $schema;
+        }
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+}

--- a/lib/Migration/Version050000Date20221116114851.php
+++ b/lib/Migration/Version050000Date20221116114851.php
@@ -54,7 +54,7 @@ class Version050000Date20221116114851 extends SimpleMigrationStep {
                 /** @var ISchemaWrapper $schema */
                 $schema = $schemaClosure();
                 $table = $schema->getTable('gpxpod_tracks');
-                if ($table->hasColumn('enabled') && $table->hasColumn('is_enabled') ) {
+                if ($table->hasColumn('enabled')) {
                         $table->dropColumn('enabled');
                 }
                 return $schema;


### PR DESCRIPTION
There seems to be still an issue with latest schema-upgrade (5.0.3) which can break loading of new UI
The setter of entity "isEnabled" tries to bind to field "enabled" (although, I guess it should bind to new column "is_enabled").

{"reqId":"xxx","level":3,"time":"2022-11-15T16:51:02+00:00","remoteAddr":"::1","user":"asc","app":"index","method":"GET","url":"/apps/gpxpod/","message":"enabled is not a valid attribute","userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:107.0) Gecko/20100101 Firefox/107.0","version":"25.0.1.1","exception":{"Exception":"BadFunctionCallException","Message":"enabled is not a valid attribute","Code":0,"Trace":[{"file":"/NEXTCLOUD_ROOT/lib/public/AppFramework/Db/Entity.php","line":165,"function":"setter","class":"OCP\\AppFramework\\Db\\Entity","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/public/AppFramework/Db/Entity.php","line":73,"function":"__call","class":"OCP\\AppFramework\\Db\\Entity","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/public/AppFramework/Db/QBMapper.php","line":322,"function":"fromRow","class":"OCP\\AppFramework\\Db\\Entity","type":"::"},{"file":"/NEXTCLOUD_ROOT/lib/public/AppFramework/Db/QBMapper.php","line":340,"function":"mapRowToEntity","class":"OCP\\AppFramework\\Db\\QBMapper","type":"->"},{"file":"/NEXTCLOUD_ROOT/apps/gpxpod/lib/Db/TrackMapper.php","line":97,"function":"findEntities","class":"OCP\\AppFramework\\Db\\QBMapper","type":"->"},{"file":"/NEXTCLOUD_ROOT/apps/gpxpod/lib/Controller/PageController.php","line":1084,"function":"getTracksOfUser","class":"OCA\\GpxPod\\Db\\TrackMapper","type":"->"},{"file":"/NEXTCLOUD_ROOT/apps/gpxpod/lib/Controller/PageController.php","line":197,"function":"cleanDbFromAbsentFiles","class":"OCA\\GpxPod\\Controller\\PageController","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/private/AppFramework/Http/Dispatcher.php","line":225,"function":"index","class":"OCA\\GpxPod\\Controller\\PageController","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/private/AppFramework/Http/Dispatcher.php","line":133,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/private/AppFramework/App.php","line":172,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/NEXTCLOUD_ROOT/lib/private/Route/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"/NEXTCLOUD_ROOT/lib/base.php","line":1047,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"/NEXTCLOUD_ROOT/index.php","line":36,"function":"handleRequest","class":"OC","type":"::"}],"File":"/NEXTCLOUD_ROOT/lib/public/AppFramework/Db/Entity.php","Line":136,"CustomMessage":"--"}}
