### PR TITLE
fix: cast GPX time SimpleXMLElement to string for DateTime

### DIFF
--- a/lib/Service/ProcessService.php
+++ b/lib/Service/ProcessService.php
@@ -611,7 +611,7 @@ class ProcessService {
 			foreach ($pointsWithCoords as $point) {
 				if (!empty($point->time)) {
 					try {
-						$firstTime = new DateTime($point->time);
+						$firstTime = new DateTime((string)$point->time);
 						if ($dateBegin === null || $firstTime < $dateBegin) {
 							$dateBegin = $firstTime;
 						}
@@ -662,7 +662,7 @@ class ProcessService {
 			$previousPoint = $pointsWithCoords[0];
 			if (!empty($previousPoint->time)) {
 				try {
-					$previousTime = new DateTime($previousPoint->time);
+					$previousTime = new DateTime((string)$previousPoint->time);
 				} catch (Exception|Throwable $e) {
 					$previousTime = null;
 				}
@@ -685,7 +685,7 @@ class ProcessService {
 					$pointTime = null;
 				} else {
 					try {
-						$pointTime = new DateTime($point->time);
+						$pointTime = new DateTime((string)$point->time);
 						$lastValidTime = $pointTime;
 					} catch (Exception|Throwable $e) {
 						$pointTime = null;
@@ -761,13 +761,13 @@ class ProcessService {
 		if (count($points) > 0) {
 			$lastPoint = $points[0];
 			try {
-				$lastTime = new DateTime($lastPoint->time);
+				$lastTime = new DateTime((string)$lastPoint->time);
 			} catch (Exception|Throwable $e) {
 				$lastTime = null;
 			}
 			foreach ($points as $point) {
 				try {
-					$time = new DateTime($point->time);
+					$time = new DateTime((string)$point->time);
 				} catch (Exception|Throwable $e) {
 					$time = null;
 				}


### PR DESCRIPTION
## Summary
- Under `declare(strict_types=1)`, `new DateTime($point->time)` throws a TypeError because `$point->time` is a `SimpleXMLElement`, not a `string`.
- Those TypeErrors were caught and ignored, so `date_begin` / `date_end` stayed `null` (UI: "No date", duration 0, no speed). Distance/elevation still worked via explicit casts.
- Cast all five GPX time values with `(string)` before constructing `DateTime`.

Fixes #101

## Test plan
- [ ] Upload / open a GPX with `<time>` on trackpoints
- [ ] Confirm Stats shows Begin/End and non-zero duration
- [ ] Reprocess an existing directory (or delete `oc_gpxpod_tracks` rows) after upgrading so markers rebuild
- [ ] Optional: `declare(strict_types=1); new DateTime((string)(new SimpleXMLElement('<t>2024-01-01T00:00:00Z</t>'))->t);` succeeds